### PR TITLE
Change from bcrypt-ruby to bcrypt

### DIFF
--- a/windows/190-miscellaneous.md
+++ b/windows/190-miscellaneous.md
@@ -27,9 +27,9 @@ thin start -p 3000 -e production
 If you get the warning `cannot load such file -- 2.0/bcrypt_ext` when running `bundle exec rake`, then you need to reinstall bcrypt-ruby
 
 ```
-gem uninstall bcrypt-ruby
+gem uninstall bcrypt
 
-gem install bcrypt-ruby --platform=ruby --no-ri --no-rdoc
+gem install bcrypt --platform=ruby --no-ri --no-rdoc
 ```
 
 


### PR DESCRIPTION
The bcrypt-ruby gem has changed its name to just bcrypt.